### PR TITLE
Fix bug with win percentage in Record class

### DIFF
--- a/fantraxapi/objs.py
+++ b/fantraxapi/objs.py
@@ -162,7 +162,8 @@ class Record:
         self.loss = int(data[fields["loss"]]["content"]) if "loss" in fields else None
         self.tie = int(data[fields["tie"]]["content"]) if "tie" in fields else None
         self.points = int(data[fields["points"]]["content"]) if "points" in fields else None
-        self.win_percentage = float(data[fields["winpc"]]["content"]) if "winpc" in fields else None
+        winpc_raw = data[fields["winpc"]]["content"] if "winpc" in fields else None
+        self.win_percentage = float(winpc_raw) if winpc_raw != "-" else 0
         self.games_back = float(data[fields["gamesback"]]["content"]) if "gamesback" in fields else None
         self.wavier_wire_order = int(data[fields["wwOrder"]]["content"]) if "wwOrder" in fields else None
         self.points_for = float(data[fields["pointsFor"]]["content"].replace(",", "")) if "pointsFor" in fields else None

--- a/fantraxapi/objs.py
+++ b/fantraxapi/objs.py
@@ -154,7 +154,6 @@ class Record:
 
     """
     def __init__(self, api, team_id, rank, fields, data):
-        print(data)
         self._api = api
         self.team = self._api.team(team_id)
         self.rank = int(rank)


### PR DESCRIPTION
## Description

Getting standings when the records have no wins or losses yet (at the beginning of the season) caused the program to crash. This PR defaults the win percentage to 0 when this is the case.

I also removed a print statement that didn't seem necessary.

### Issues Fixed or Closed

N/A

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
