### PR TITLE
fix league init keyerror

### DIFF
--- a/fantraxapi/objs/league.py
+++ b/fantraxapi/objs/league.py
@@ -80,7 +80,8 @@ class League:
             key = scoring_date.strftime("%b %d")
             if "0" in key and not key.endswith("0"):
                 key = key.replace("0", "")
-            self.scoring_dates[period_to_day_list[key]] = scoring_date
+            if key in period_to_day_list:
+                self.scoring_dates[period_to_day_list[key]] = scoring_date
         self.scoring_periods = {p["value"]: ScoringPeriod(self, p) for p in responses[3]["displayedLists"]["scoringPeriodList"] if p["name"] != "Full Season"}
         self._scoring_periods_lookup = None
         self._update_teams(responses[3]["fantasyTeams"])


### PR DESCRIPTION
## Description

all scheduled game dates are looked up in `periodList` but `periodList` only contains stuff that's already been processed (maybe offseason only? idk). regardless, game dates can exist in `dates` but not `periodList`. 

### Issues Fixed or Closed

- fixes #8.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code